### PR TITLE
Fix pyperclip crash

### DIFF
--- a/totp.py
+++ b/totp.py
@@ -46,6 +46,6 @@ if args.add:
         keyring.set_password(args.service, args.account, secret)
 else:
     # Generate TOTP, copy to clipboard (unless --print-only) and print
-    token = otp.get_totp(secret, as_string=True)
+    token = otp.get_totp(secret, as_string=True).decode('UTF-8')
     args.print_only or pyperclip.copy(token)
     print(token)


### PR DESCRIPTION
Decode token from bytes to UTF-8 before printing/copying to clipboard.

This allows printing without the b'TOKEN' syntax of python and pyperclip to copy string to clipboard (raw bytes not supported).

Fixes https://github.com/twilfong/totp-auth/issues/2